### PR TITLE
[CB-97] ci: :green_heart: Added test config to ignore popup test in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "webpack --config webpack/webpack.config.js",
     "test": "jest --watchAll",
+    "test:ci": "jest --watchAll=false --ci --coverage --testPathIgnorePatterns popup.test.tsx",
     "coverage": "jest --watchAll=false --coverage"
   },
   "repository": {


### PR DESCRIPTION
## Feature Description
Related to [CB-97](https://chessboom.atlassian.net/browse/CB-97?atlOrigin=eyJpIjoiMjFkMTdiNDRiM2YwNDRhZWFmZjM2ODFlNDZjN2MwMmMiLCJwIjoiaiJ9). Puppeteer testing suite is not compatible with Github Actions and should be run on GUI to generate proper coverage. Excluding this via test:ci allows for builds to pass normally.