### PR TITLE
[CB-101] Add specific file location for pgn file downloads

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -3,6 +3,7 @@ import { getReadableStream, handleStreamResponse } from "./streamUtils";
 
 const downloadMimetype = "application/x-chess-pgn";
 const gameEventMimetype = "application/x-ndjson";
+const downloadPath = "CBoom/gameFiles/"
 const token = ""; // don't forget to add your token here!
 const ext = "pgn";
 
@@ -46,7 +47,7 @@ export function apiDownloadGame(gameId: string): void {
         .then(stream => new Response(stream, { headers: { "Content-Type": "text/plain" } }).text())
         .then(gameData => {
             const url = `data:${downloadMimetype},${gameData}`;
-            const filename = `${gameId}.${ext}`
+            const filename = `${downloadPath}${gameId}.${ext}`
 
             download(url, filename);
         });


### PR DESCRIPTION
## Feature Description
[CB-101](https://chessboom.atlassian.net/browse/CB-101) 
Added a specific file location to download pgn files instead of a default location.

# Testing
Play a lichess game and use the extension to download the game file.
You will see that it automatically creates and downloads to Downloads/CBoom/gameFiles. 

